### PR TITLE
Tweaked Env vars

### DIFF
--- a/historical/tests/test_s3.py
+++ b/historical/tests/test_s3.py
@@ -175,7 +175,7 @@ def test_poller(historical_role, buckets, mock_lambda_environment, historical_ki
     # Check that an exception raised doesn't break things:
     import historical.s3.poller
 
-    def mocked_poller(account):
+    def mocked_poller(account, stream):
         raise ClientError({"Error": {"Message": "", "Code": "AccessDenied"}}, "sts:AssumeRole")
 
     old_method = historical.s3.poller.create_polling_event  # For pytest inter-test issues...


### PR DESCRIPTION
Environment variables tweaked to support a separate kinesis stream specific for polling events.

Context: Polling events take a very long time to process if you have many, many buckets.