### PR TITLE
Fix swag-client version to not break tools dependent on swag-client a…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,13 @@ with open(os.path.join(ROOT, "historical", "__about__.py")) as f:
 
 
 install_requires = [
-    'cloudaux==1.4.3',
+    'cloudaux>=1.4.3',
     'boto3>=1.4.4',
-    'click==6.7',
-    'pynamodb==3.1.0',
-    'deepdiff==3.3.0',
+    'click>=6.7',
+    'pynamodb>=3.1.0',
+    'deepdiff>=3.3.0',
     'raven-python-lambda',
-    'marshmallow==2.13.5',
+    'marshmallow>=2.13.5',
     'swag-client>=0.3.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'deepdiff==3.3.0',
     'raven-python-lambda',
     'marshmallow==2.13.5',
-    'swag-client==0.3.0',
+    'swag-client>=0.3.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
This fixes the setup.py so that projects with both a swag-client and historical dependency can successfully install via pip install