### PR TITLE
Comparing all fields for changes

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/common/dynamodb.py
+++ b/historical/common/dynamodb.py
@@ -22,9 +22,7 @@ def default_diff(latest_config, current_config):
 
 def remove_current_specific_fields(obj):
     """Remove all fields that belong to the Current table -- that don't belong in the Durable table"""
-    # TTL:
     obj.pop("ttl", None)
-
     return obj
 
 
@@ -42,8 +40,8 @@ def modify_record(durable_model, current_revision, arn, event_time, diff_func):
     if items:
         latest_revision = items[0]
 
-        latest_config = latest_revision._get_json()[1]['attributes']['configuration']
-        current_config = current_revision._get_json()[1]['attributes']['configuration']
+        latest_config = latest_revision._get_json()[1]['attributes']
+        current_config = current_revision._get_json()[1]['attributes']
 
         # Determine if there is truly a difference, disregarding Ephemeral Paths
         diff = diff_func(latest_config, current_config)

--- a/historical/s3/differ.py
+++ b/historical/s3/differ.py
@@ -23,7 +23,7 @@ log.setLevel(logging.WARNING)
 # Path to where in the dict the ephemeral field is -- starting with "root['M'][PathInConfigDontForgetDataType]..."
 EPHEMERAL_PATHS = [
     # Configuration level changes are don't care about:
-    "root['M']['_version']"
+    "root['configuration']['M']['_version']"
 ]
 
 

--- a/historical/tests/test_s3.py
+++ b/historical/tests/test_s3.py
@@ -342,8 +342,6 @@ def test_differ(durable_s3_table, mock_lambda_environment):
     ephemeral_changes["eventTime"] = \
         datetime(year=2017, month=5, day=12, hour=11, minute=30, second=0).isoformat() + 'Z'
     ephemeral_changes["configuration"]["_version"] = 99999
-    ephemeral_changes["principalId"] = "someoneelse@example.com"
-    ephemeral_changes["userIdentity"]["sessionContext"]["userName"] = "someoneelse"
     ephemeral_changes["ttl"] = ttl
 
     data = DynamoDBRecordsFactory(


### PR DESCRIPTION
Previously we were only looking at configuration changes. There is a corner case where if you choose to add a new top level field to the model, it would not be seen as a "difference" and thus not propagated to the durable table. Older revisions will indeed not get this new field but "current" ones will. It's up for debate whether we should backfill old durable tables with this new schema information.