### PR TITLE
Correcting confusion with regions

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/models.py
+++ b/historical/models.py
@@ -41,7 +41,6 @@ class CurrentHistoricalModel(object):
 
 class AWSHistoricalMixin(object):
     arn = UnicodeAttribute(hash_key=True)
-    region = UnicodeAttribute(default=CURRENT_REGION)
     accountId = UnicodeAttribute()
     userIdentity = MapAttribute(null=True)
     principalId = UnicodeAttribute(null=True)

--- a/historical/s3/collector.py
+++ b/historical/s3/collector.py
@@ -78,7 +78,7 @@ def create_delete_model(record):
         'accountId': record['account'],
         'eventTime': record['detail']['eventTime'],
         'BucketName': cloudwatch.filter_request_parameters('bucketName', record),
-        'region': cloudwatch.get_region(record),
+        'Region': cloudwatch.get_region(record),
         'Tags': {},
         'configuration': {}
     }
@@ -159,7 +159,7 @@ def process_update_records(update_records):
                 "accountId": account_id,
                 "eventTime": item["eventDetails"]["detail"]["eventTime"],
                 "BucketName": b,
-                "region": bucket_details["Region"],
+                "Region": bucket_details["Region"],
                 # Duplicated in top level and configuration for secondary index
                 "Tags": bucket_details["Tags"] or {}
             }

--- a/historical/s3/models.py
+++ b/historical/s3/models.py
@@ -17,17 +17,20 @@ from historical.models import DurableHistoricalModel, CurrentHistoricalModel, AW
 
 class S3Model(object):
     BucketName = UnicodeAttribute()
+    Region = UnicodeAttribute()
     Tags = MapAttribute()
 
 
 class DurableS3Model(Model, DurableHistoricalModel, AWSHistoricalMixin, S3Model):
     class Meta:
         table_name = 'HistoricalS3DurableTable'
+        region = CURRENT_REGION
 
 
 class CurrentS3Model(Model, CurrentHistoricalModel, AWSHistoricalMixin, S3Model):
     class Meta:
         table_name = 'HistoricalS3CurrentTable'
+        region = CURRENT_REGION
 
 
 class ViewIndex(GlobalSecondaryIndex):

--- a/historical/tests/test_s3.py
+++ b/historical/tests/test_s3.py
@@ -45,7 +45,7 @@ S3_BUCKET = {
     "accountId": "123456789012",
     "eventTime": "2017-09-08T00:34:34Z",
     "BucketName": "testbucket1",
-    "region": "us-east-1",
+    "Region": "us-east-1",
     "Tags": {},
     "configuration": {
         "Grants": {

--- a/historical/tests/test_vpc.py
+++ b/historical/tests/test_vpc.py
@@ -30,6 +30,7 @@ VPC = {
     'State': 'available',
     'Name': 'vpc0',
     'Tags': [{'Key': 'name', 'Value': 'vpc0'}],
+    'Region': 'us-east-1',
     'configuration': {
             'CidrBlock': 'string',
             'DhcpOptionsId': 'string',

--- a/historical/vpc/collector.py
+++ b/historical/vpc/collector.py
@@ -165,7 +165,8 @@ def capture_update_records(records):
             'State': vpc.get('State'),
             'IsDefault': vpc.get('IsDefault'),
             'CidrBlock': vpc.get('CidrBlock'),
-            'Name': get_vpc_name(vpc)
+            'Name': get_vpc_name(vpc),
+            'Region': cloudwatch.get_region(record)
         })
 
         log.debug('Writing Dynamodb Record. Records: {record}'.format(record=data))

--- a/historical/vpc/models.py
+++ b/historical/vpc/models.py
@@ -28,6 +28,7 @@ class VPCModel(object):
     Tags = ListAttribute()
     IsDefault = BooleanAttribute()
     Name = UnicodeAttribute(null=True)
+    Region = UnicodeAttribute()
 
 
 class DurableVPCModel(Model, DurableHistoricalModel, AWSHistoricalMixin, VPCModel):

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,10 @@ Historical
 Allows for the tracking of AWS configuration data across accounts/regions/technologies.
 
 """
-import sys
 import os.path
+import sys
 
-import subprocess
-from distutils import log
 from setuptools import setup, find_packages
-from setuptools.command.install import install
-
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__)))
 


### PR DESCRIPTION
- Meta class `region` is for where the Dynamo table lives
- Technologies with regional affinity must have `Region` set

Version 0.1.6