### PR TITLE
Global DynamoDB Logic Update

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.1.9"
+__version__ = "0.2.0"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/common/cloudwatch.py
+++ b/historical/common/cloudwatch.py
@@ -67,5 +67,8 @@ def get_historical_base_info(event):
     if event['detail'].get('eventTime'):
         data['eventTime'] = event['detail']['eventTime']
 
+    if event['detail'].get("source"):
+        data['eventSource'] = event['detail']['source']
+
     return data
 

--- a/historical/constants.py
+++ b/historical/constants.py
@@ -1,3 +1,13 @@
+"""
+.. module: historical.constants
+    :platform: Unix
+    :copyright: (c) 2017 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. author:: Mike Grima <mgrima@netflix.com>
+.. author:: Kevin Glisson <kglisson@netflix.com>
+"""
 import os
 CURRENT_REGION = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
 HISTORICAL_ROLE = os.environ.get('HISTORICAL_ROLE', 'Historical')
+POLL_REGIONS = os.environ.get('POLL_REGIONS', 'us-east-1').split(",")
+DIFF_REGIONS = os.environ.get('DIFF_REGIONS', "us-east-1").split(",")

--- a/historical/historical-cookiecutter/historical_{{cookiecutter.technology_slug}}/{{cookiecutter.technology_slug}}/differ.py
+++ b/historical/historical-cookiecutter/historical_{{cookiecutter.technology_slug}}/{{cookiecutter.technology_slug}}/differ.py
@@ -9,7 +9,7 @@ import logging
 
 from raven_python_lambda import RavenLambdaWrapper
 
-from historical.common.dynamodb import process_dynamodb_record
+from historical.common.dynamodb import process_dynamodb_differ_record
 from .models import Durable{{cookiecutter.technology_slug | titlecase}}Model
 
 logging.basicConfig()
@@ -26,4 +26,4 @@ def handler(event, context):
     historical record.
     """
     for record in event['Records']:
-        process_dynamodb_record(record, Durable{{cookiecutter.technology_slug | titlecase}}Model)
+        process_dynamodb_differ_record(record, Durable{{cookiecutter.technology_slug | titlecase}}Model)

--- a/historical/models.py
+++ b/historical/models.py
@@ -37,6 +37,7 @@ class DurableHistoricalModel(object):
 class CurrentHistoricalModel(object):
     eventTime = EventTimeAttribute(default=default_event_time)
     ttl = NumberAttribute(default=default_ttl())
+    eventSource = UnicodeAttribute()
 
 
 class AWSHistoricalMixin(object):

--- a/historical/s3/collector.py
+++ b/historical/s3/collector.py
@@ -80,7 +80,8 @@ def create_delete_model(record):
         'BucketName': cloudwatch.filter_request_parameters('bucketName', record),
         'Region': cloudwatch.get_region(record),
         'Tags': {},
-        'configuration': {}
+        'configuration': {},
+        'eventSource': record["detail"]["source"]
     }
 
     return CurrentS3Model(**data)
@@ -168,7 +169,8 @@ def process_update_records(update_records):
                 "BucketName": b,
                 "Region": bucket_details["Region"],
                 # Duplicated in top level and configuration for secondary index
-                "Tags": bucket_details["Tags"] or {}
+                "Tags": bucket_details["Tags"] or {},
+                "eventSource": item["eventDetails"]["detail"]["source"]
             }
 
             # Remove the fields we don't care about:

--- a/historical/s3/differ.py
+++ b/historical/s3/differ.py
@@ -12,7 +12,7 @@ from deepdiff import DeepDiff
 from raven_python_lambda import RavenLambdaWrapper
 
 from historical.s3.models import DurableS3Model
-from historical.common.dynamodb import process_dynamodb_record
+from historical.common.dynamodb import process_dynamodb_differ_record
 
 deser = TypeDeserializer()
 
@@ -47,4 +47,4 @@ def handler(event, context):
     historical record.
     """
     for record in event['Records']:
-        process_dynamodb_record(record, DurableS3Model, diff_func=is_new_revision)
+        process_dynamodb_differ_record(record, DurableS3Model, diff_func=is_new_revision)

--- a/historical/security_group/differ.py
+++ b/historical/security_group/differ.py
@@ -9,7 +9,7 @@ import logging
 
 from raven_python_lambda import RavenLambdaWrapper
 
-from historical.common.dynamodb import process_dynamodb_record
+from historical.common.dynamodb import process_dynamodb_differ_record
 from historical.security_group.models import DurableSecurityGroupModel
 
 logging.basicConfig()
@@ -26,4 +26,4 @@ def handler(event, context):
     historical record.
     """
     for record in event['Records']:
-        process_dynamodb_record(record, DurableSecurityGroupModel)
+        process_dynamodb_differ_record(record, DurableSecurityGroupModel)

--- a/historical/vpc/differ.py
+++ b/historical/vpc/differ.py
@@ -9,7 +9,7 @@ import logging
 
 from raven_python_lambda import RavenLambdaWrapper
 
-from historical.common.dynamodb import process_dynamodb_record
+from historical.common.dynamodb import process_dynamodb_differ_record
 from historical.vpc.models import DurableVPCModel
 
 logging.basicConfig()
@@ -26,4 +26,4 @@ def handler(event, context):
     historical record.
     """
     for record in event['Records']:
-        process_dynamodb_record(record, DurableVPCModel)
+        process_dynamodb_differ_record(record, DurableVPCModel)


### PR DESCRIPTION
Updating logic to address complexities introduced with Global DynamoDB tables.

Namely:
For all technologies, the Differ Lambda will only process data that is specified in the `DIFF_REGIONS` environment variable.

For **REGIONAL** technologies, the Poller Lambda will only poll for regions that are defined in the `POLL_REGIONS` environment variable.