### PR TITLE
Added randomness support for polling to avoid spiking

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/constants.py
+++ b/historical/constants.py
@@ -22,6 +22,12 @@ def extract_log_level_from_environment(k, default):
     return log_levels.get(os.environ.get(k)) or int(os.environ.get(k, default))
 
 
+# 24 hours in seconds is the default
+TTL_EXPIRY = int(os.environ.get('TTL_EXPIRY', 86400))
+
+# By default, don't randomize the pollers (tasker or collector -- same env var):
+RANDOMIZE_POLLER = int(os.environ.get('RANDOMIZE_POLLER', 0))
+
 CURRENT_REGION = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
 HISTORICAL_ROLE = os.environ.get('HISTORICAL_ROLE', 'Historical')
 POLL_REGIONS = os.environ.get('POLL_REGIONS', 'us-east-1').split(",")

--- a/historical/models.py
+++ b/historical/models.py
@@ -12,13 +12,11 @@ from datetime import datetime
 from marshmallow import Schema, fields
 from pynamodb.attributes import UnicodeAttribute, MapAttribute, NumberAttribute
 
+from historical.constants import TTL_EXPIRY
 from historical.attributes import EventTimeAttribute
 
 
-TTL_EXPIRY = 86400  # 24 Hours in seconds
-
-EPHEMERAL_PATHS = [
-]
+EPHEMERAL_PATHS = []
 
 
 def default_ttl():

--- a/historical/tests/test_s3.py
+++ b/historical/tests/test_s3.py
@@ -225,7 +225,7 @@ def test_poller_processor_handler(historical_role, buckets, mock_lambda_environm
     # Check that an exception raised doesn't break things:
     import historical.s3.poller
 
-    def mocked_poller(account, stream):
+    def mocked_poller(account, stream, randomize_delay=0):
         raise ClientError({"Error": {"Message": "", "Code": "AccessDenied"}}, "sts:AssumeRole")
 
     old_method = historical.s3.poller.produce_events  # For pytest inter-test issues...


### PR DESCRIPTION
New environment variable `RANDOMIZE_POLLER`, which introduces randomness to the poller.

This is to help avoid major spikes in API calls when calling the poller.

Bumps up the version.