### PR TITLE
SWAG test account flag

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/common/accounts.py
+++ b/historical/common/accounts.py
@@ -4,11 +4,23 @@
     :copyright: (c) 2018 by Netflix Inc., see AUTHORS for more
     :license: Apache, see LICENSE for more details.
 .. author:: Kevin Glisson <kglisson@netflix.com>
+.. author:: Mike Grima <mgrima@netflix.com>
 """
 import os
 
 from swag_client.backend import SWAGManager
 from swag_client.util import parse_swag_config_options
+
+
+def parse_boolean(value):
+    """Simple function to get a boolean value from string."""
+    if not value:
+        return False
+
+    if str(value).lower() == 'true':
+        return True
+
+    return False
 
 
 def get_historical_accounts():
@@ -21,9 +33,13 @@ def get_historical_accounts():
             'swag.region': os.environ.get('SWAG_REGION', 'us-east-1')
         }
         swag = SWAGManager(**parse_swag_config_options(swag_opts))
-        accounts = swag.get_service_enabled('historical', search_filter="[?provider=='aws'] && [?owner=='{}']".format(os.environ['SWAG_OWNER']))
+        search_filter = "[?provider=='aws'] && [?owner=='{}']".format(os.environ['SWAG_OWNER'])
+
+        if parse_boolean(os.environ.get('TEST_ACCOUNTS_ONLY')):
+            search_filter += " && [?environment=='test']"
+
+        accounts = swag.get_service_enabled('historical', search_filter=search_filter)
     else:
         accounts = os.environ['ENABLED_ACCOUNTS']
 
     return accounts
-


### PR DESCRIPTION
Added an environment variable flag `TEST_ACCOUNTS_ONLY` to ensure that Historical can only iterate over "test" accounts defined in SWAG.

This is useful to have a testing stack of Historical running without touching sensitive or production accounts where it can consume the available API calls.