### PR TITLE
Added a simple proxy for the Durable table

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.3.20"
+__version__ = "0.4.0"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/attributes.py
+++ b/historical/attributes.py
@@ -67,6 +67,30 @@ def decimal_default(obj):
     raise TypeError
 
 
+def fix_decimals(obj):
+    """Removes the stupid Decimals
+       See: https://github.com/boto/boto3/issues/369#issuecomment-302137290
+    """
+    if isinstance(obj, list):
+        for i in range(len(obj)):
+            obj[i] = fix_decimals(obj[i])
+        return obj
+
+    elif isinstance(obj, dict):
+        for key, value in obj.items():
+            obj[key] = fix_decimals(value)
+        return obj
+
+    elif isinstance(obj, decimal.Decimal):
+        if obj % 1 == 0:
+            return int(obj)
+        else:
+            return float(obj)
+
+    else:
+        return obj
+
+
 class HistoricalDecimalAttribute(Attribute):
     """
     A number attribute

--- a/historical/constants.py
+++ b/historical/constants.py
@@ -9,6 +9,8 @@
 import logging
 import os
 
+from enum import Enum
+
 log_levels = {
     'CRITICAL': logging.CRITICAL,
     'ERROR': logging.ERROR,
@@ -33,5 +35,14 @@ HISTORICAL_ROLE = os.environ.get('HISTORICAL_ROLE', 'Historical')
 POLL_REGIONS = os.environ.get('POLL_REGIONS', 'us-east-1').split(",")
 PROXY_REGIONS = os.environ.get('PROXY_REGIONS', 'us-east-1').split(",")
 REGION_ATTR = os.environ.get('REGION_ATTR', 'Region')
+SIMPLE_DURABLE_PROXY = os.environ.get('SIMPLE_DURABLE_PROXY', False)
 LOGGING_LEVEL = extract_log_level_from_environment('LOGGING_LEVEL', logging.INFO)
 EVENT_TOO_BIG_FLAG = "event_too_big"
+
+
+class DurableEventTypes(Enum):
+    CREATE = 'CREATE'
+    UPDATE = 'UPDATE'
+    DELETE = 'DELETE'
+    # EXPIRE = 'EXPIRE'  # Future TTLs on Durable tables??
+

--- a/historical/mapping/__init__.py
+++ b/historical/mapping/__init__.py
@@ -1,0 +1,30 @@
+"""
+.. module: historical.mapping
+    :platform: Unix
+    :copyright: (c) 2017 by Netflix Inc., see AUTHORS for more
+    :license: Apache, see LICENSE for more details.
+.. author:: Mike Grima <mgrima@netflix.com>
+"""
+
+import os
+
+from historical.security_group.models import CurrentSecurityGroupModel, DurableSecurityGroupModel
+from historical.s3.models import CurrentS3Model, DurableS3Model
+from historical.vpc.models import CurrentVPCModel, DurableVPCModel
+
+# The HISTORICAL_TECHNOLOGY variable MUST be equal to that of an existing model's 'tech' Meta field.
+HISTORICAL_TECHNOLOGY = os.environ.get('HISTORICAL_TECHNOLOGY')
+
+# Current Table Mapping:
+CURRENT_MAPPING = {
+    CurrentSecurityGroupModel.Meta.tech: CurrentSecurityGroupModel,
+    CurrentS3Model.Meta.tech: CurrentS3Model,
+    CurrentVPCModel.Meta.tech: CurrentVPCModel
+}
+
+# Durable Table Mapping:
+DURABLE_MAPPING = {
+    DurableSecurityGroupModel.Meta.tech: DurableSecurityGroupModel,
+    DurableS3Model.Meta.tech: DurableS3Model,
+    DurableVPCModel.Meta.tech: DurableVPCModel
+}

--- a/historical/s3/differ.py
+++ b/historical/s3/differ.py
@@ -6,7 +6,6 @@
 .. author:: Mike Grima <mgrima@netflix.com>
 """
 import logging
-from boto3.dynamodb.types import TypeDeserializer
 from deepdiff import DeepDiff
 
 from raven_python_lambda import RavenLambdaWrapper
@@ -15,8 +14,6 @@ from historical.common.util import deserialize_records
 from historical.constants import LOGGING_LEVEL
 from historical.s3.models import DurableS3Model, CurrentS3Model
 from historical.common.dynamodb import process_dynamodb_differ_record
-
-deser = TypeDeserializer()
 
 logging.basicConfig()
 log = logging.getLogger('historical')

--- a/historical/s3/models.py
+++ b/historical/s3/models.py
@@ -21,19 +21,20 @@ VERSION = 9
 class S3Model(object):
     BucketName = UnicodeAttribute()
     Region = UnicodeAttribute()
-    Tags = MapAttribute()
 
 
 class DurableS3Model(DurableHistoricalModel, AWSHistoricalMixin, S3Model):
     class Meta:
         table_name = 'HistoricalS3DurableTable'
         region = CURRENT_REGION
+        tech = 's3'
 
 
 class CurrentS3Model(CurrentHistoricalModel, AWSHistoricalMixin, S3Model):
     class Meta:
         table_name = 'HistoricalS3CurrentTable'
         region = CURRENT_REGION
+        tech = 's3'
 
 
 class ViewIndex(GlobalSecondaryIndex):

--- a/historical/security_group/models.py
+++ b/historical/security_group/models.py
@@ -26,7 +26,6 @@ class SecurityGroupModel(object):
     GroupId = UnicodeAttribute()
     GroupName = UnicodeAttribute()
     VpcId = UnicodeAttribute(null=True)
-    Tags = MapAttribute()
     Region = UnicodeAttribute()
 
 
@@ -34,12 +33,14 @@ class DurableSecurityGroupModel(DurableHistoricalModel, AWSHistoricalMixin, Secu
     class Meta:
         table_name = 'HistoricalSecurityGroupDurableTable'
         region = CURRENT_REGION
+        tech = 'securitygroup'
 
 
 class CurrentSecurityGroupModel(CurrentHistoricalModel, AWSHistoricalMixin, SecurityGroupModel):
     class Meta:
         table_name = 'HistoricalSecurityGroupCurrentTable'
         region = CURRENT_REGION
+        tech = 'securitygroup'
 
 
 class ViewIndex(GlobalSecondaryIndex):

--- a/historical/vpc/models.py
+++ b/historical/vpc/models.py
@@ -27,7 +27,6 @@ class VPCModel(object):
     VpcId = UnicodeAttribute()
     State = UnicodeAttribute()
     CidrBlock = UnicodeAttribute()
-    Tags = MapAttribute()
     IsDefault = BooleanAttribute()
     Name = UnicodeAttribute(null=True)
     Region = UnicodeAttribute()
@@ -37,12 +36,14 @@ class DurableVPCModel(DurableHistoricalModel, AWSHistoricalMixin, VPCModel):
     class Meta:
         table_name = 'HistoricalVPCDurableTable'
         region = CURRENT_REGION
+        tech = 'vpc'
 
 
 class CurrentVPCModel(CurrentHistoricalModel, AWSHistoricalMixin, VPCModel):
     class Meta:
         table_name = 'HistoricalVPCCurrentTable'
         region = CURRENT_REGION
+        tech = 'vpc'
 
 
 class ViewIndex(GlobalSecondaryIndex):

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'deepdiff>=3.3.0',
     'raven-python-lambda>=0.1.7',
     'marshmallow>=2.13.5',
-    'swag-client==0.4.2',
+    'swag-client==0.4.3',
     'python-dateutil==2.6.1'
 ]
 


### PR DESCRIPTION
This is more useful for applications that want to listen to events from historical, as they don't need to care about de-serializing DynamoDB data.