### PR TITLE
Fixed some logic bugs and also some DynamoDB gotchas

### DIFF
--- a/historical/__about__.py
+++ b/historical/__about__.py
@@ -9,7 +9,7 @@ __title__ = "historical"
 __summary__ = ("Historical tracking of AWS configuration data.")
 __uri__ = "https://github.com/Netflix-Skunkworks/historical"
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __author__ = "The Historical developers"
 __email__ = "security@netflix.com"

--- a/historical/common/dynamodb.py
+++ b/historical/common/dynamodb.py
@@ -43,9 +43,9 @@ def default_diff(latest_config, current_config):
 def remove_global_dynamo_specific_fields(obj):
     """Remove all fields that are placed in by DynamoDB for global tables"""
     # https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables_HowItWorks.html
-    obj.pop("aws:rep:deleting", None)
-    obj.pop("aws:rep:updatetime", None)
-    obj.pop("aws:rep:updateregion", None)
+    obj.pop('aws:rep:deleting', None)
+    obj.pop('aws:rep:updatetime', None)
+    obj.pop('aws:rep:updateregion', None)
 
     return obj
 

--- a/historical/constants.py
+++ b/historical/constants.py
@@ -9,8 +9,6 @@
 import logging
 import os
 
-from enum import Enum
-
 log_levels = {
     'CRITICAL': logging.CRITICAL,
     'ERROR': logging.ERROR,
@@ -38,11 +36,3 @@ REGION_ATTR = os.environ.get('REGION_ATTR', 'Region')
 SIMPLE_DURABLE_PROXY = os.environ.get('SIMPLE_DURABLE_PROXY', False)
 LOGGING_LEVEL = extract_log_level_from_environment('LOGGING_LEVEL', logging.INFO)
 EVENT_TOO_BIG_FLAG = "event_too_big"
-
-
-class DurableEventTypes(Enum):
-    CREATE = 'CREATE'
-    UPDATE = 'UPDATE'
-    DELETE = 'DELETE'
-    # EXPIRE = 'EXPIRE'  # Future TTLs on Durable tables??
-


### PR DESCRIPTION
This should prevent the noisy global table events.

This should also finalize the simplified data event by removing the `old_image` field since that won't be found as all new durable items are always appended.